### PR TITLE
Consider upgrading to the 2.x line of Spark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.iml
+.classpath
+.project
+.settings/
+.idea/
+target/
+release.properties
+
+

--- a/convert-mnist-data.sh
+++ b/convert-mnist-data.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # save images and labels as CSV files
-spark-submit \
+spark2-submit \
 --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=./TF/tf_env/bin/python \
 --conf spark.yarn.appMasterEnv.PYSPARK_DRIVER_PYTHON=./TF/tf_env/bin/python \
 --master yarn \

--- a/train-mnist-dist.sh
+++ b/train-mnist-dist.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-spark-submit \
+spark2-submit \
 --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=./TF/tf_env/bin/python \
 --conf spark.yarn.appMasterEnv.PYSPARK_DRIVER_PYTHON=./TF/tf_env/bin/python \
 --master yarn \


### PR DESCRIPTION
Currently the project calls the 1.x line of Spark in `convert-mnist-data.sh` and `train-mnist-dist.sh`.

Given the purpose of running it in a CDH environment possibly with CDSW I would suggest to use Spark2.

Tested it, the former script runs fine, the latter one produces the known error.

The pull request also adds a .gitignore file for convenient development.